### PR TITLE
Fix parsing Android version & other improvements

### DIFF
--- a/dexDump.js
+++ b/dexDump.js
@@ -33,7 +33,7 @@ function getAndroidVersion(){
     }else{
         logPrint("Error: cannot get android version");
     }
-    logPrint("Android Version: " + version);
+    logPrint("[*] Android version: " + version);
 
     return version;
 }
@@ -50,11 +50,11 @@ function getFunctionName(){
         for(i = 0; i< artExports.length; i++){
             if(artExports[i].name.indexOf("OpenMemory") !== -1){
                 functionName = artExports[i].name;
-                logPrint("index " + i + " function name: "+ functionName);
+                logPrint("[*] Export index: " + i + " -> "+ functionName);
                 break;
             }else if(artExports[i].name.indexOf("OpenCommon") !== -1){
                 functionName = artExports[i].name;
-                logPrint("index " + i + " function name: "+ functionName);
+                logPrint("[*] Export index: " + i + " -> "+ functionName);
                 break;
             }
         }
@@ -64,7 +64,7 @@ function getFunctionName(){
             for(i = 0; i< dvmExports.length; i++){
                 if(dvmExports[i].name.indexOf("dexFileParse") !== -1){
                     functionName = dvmExports[i].name;
-                    logPrint("index " + i + " function name: "+ functionName);
+                    logPrint("[*] Export index: " + i + " -> "+ functionName);
                     break;
                 }
             }
@@ -73,7 +73,7 @@ function getFunctionName(){
             for(i = 0; i< dvmExports.length; i++){
                 if(dvmExports[i].name.indexOf("OpenMemory") !== -1){
                     functionName = dvmExports[i].name;
-                    logPrint("index " + i + " function name: "+ functionName);
+                    logPrint("[*] Export index: " + i + " -> "+ functionName);
                     break;
                 }
             }
@@ -102,7 +102,7 @@ function getg_processName(){
         var ret = fgetsFunc(buffData, 128, fp);
         if(ret !== 0){
             g_processName = Memory.readCString(buffData);
-            logPrint("g_processName " + g_processName);
+            logPrint("[*] ProcessName: " + g_processName);
         }
         fcloseFunc(fp);
     }

--- a/dexDump.js
+++ b/dexDump.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Author: guoqiangck
+ * Author: guoqiangck & enovella
  * Created: 2019/6/11
  * Dump dex file for packed apks
  * Hook art/runtime/dex_file.cc OpenMemory or OpenCommon
@@ -58,7 +58,7 @@ function getFunctionName(){
         }
     }else{ //android 4
         var dvmExports =  Module.enumerateExportsSync("libdvm.so");
-        if(dvmExports.length !== 0){  // check libdvm.so first
+        if (dvmExports.length !== 0) {
             for(i = 0; i< dvmExports.length; i++){
                 if(dvmExports[i].name.indexOf("dexFileParse") !== -1){
                     functionName = dvmExports[i].name;
@@ -66,7 +66,7 @@ function getFunctionName(){
                     break;
                 }
             }
-        }else{ // if not load libdvm.so, check libart.so
+        }else {
             dvmExports = Module.enumerateExportsSync("libart.so");
             for(i = 0; i< dvmExports.length; i++){
                 if(dvmExports[i].name.indexOf("OpenMemory") !== -1){
@@ -84,10 +84,11 @@ function getProcessName(){
     var processName = "";
 
     var fopenPtr = Module.findExportByName("libc.so", "fopen");
-    var fopenFunc = new NativeFunction(fopenPtr, 'pointer', ['pointer', 'pointer']);
     var fgetsPtr = Module.findExportByName("libc.so", "fgets");
-    var fgetsFunc = new NativeFunction(fgetsPtr, 'int', ['pointer', 'int', 'pointer']);
     var fclosePtr = Module.findExportByName("libc.so", "fclose");
+
+    var fopenFunc = new NativeFunction(fopenPtr, 'pointer', ['pointer', 'pointer']);
+    var fgetsFunc = new NativeFunction(fgetsPtr, 'int', ['pointer', 'int', 'pointer']);
     var fcloseFunc = new NativeFunction(fclosePtr, 'int', ['pointer']);
 
     var pathPtr = Memory.allocUtf8String("/proc/self/cmdline");
@@ -144,6 +145,7 @@ function checkOdexMagic(dataAddr){
 
     return magicMatch;
 }
+
 function dumpDexToFile(isDex, begin, processName) {
     //console.log(hexdump(begin, { offset: 0, header: false, length: 64, ansi: false }));
     var dexType;
@@ -181,33 +183,33 @@ function dumpDex(moduleFuncName, processName){
                 var odexMagicMatch = false;
 
                 dexMagicMatch = checkDexMagic(args[0]);
-                if(dexMagicMatch === true){
+                if (dexMagicMatch === true){
                     begin = args[0];
-                }else{
+                }else {
                     odexMagicMatch = checkOdexMagic(args[0]);
-                    if(odexMagicMatch === true){
+                    if (odexMagicMatch === true) {
                         begin = args[0];
                     }
                 }
 
-                if(begin === 0){
+                if (begin === 0){
                     dexMagicMatch = checkDexMagic(args[1]);
-                    if(dexMagicMatch === true){
+                    if(dexMagicMatch === true) {
                         begin = args[1];
                     }else{
                       odexMagicMatch = checkOdexMagic(args[1]);
-                      if(odexMagicMatch === true){
+                      if(odexMagicMatch === true) {
                           begin = args[1];
                       }
                     }
                 }
-                if(dexMagicMatch === true){
+                if (dexMagicMatch === true) {
                     dumpDexToFile(dexMagicMatch, begin, processName);
-                } else if(odexMagicMatch === true){
+                } else if(odexMagicMatch === true) {
                     dumpDexToFile(odexMagicMatch, begin, processName);
                 }
             },
-            onLeave: function(retval){
+            onLeave: function(retval) {
             }
         });
     }else{

--- a/dexDump.js
+++ b/dexDump.js
@@ -28,8 +28,7 @@ function getAndroidVersion(){
     var version = 0;
 
     if(Java.available){
-        var versionStr = Java.androidVersion;
-        version = versionStr.slice(0,1);
+        var version = parseInt(Java.androidVersion);
     }else{
         LogPrint("Error: cannot get android version");
     }

--- a/dexDump.js
+++ b/dexDump.js
@@ -144,12 +144,12 @@ function checkOdexMagic(dataAddr){
 
     return magicMatch;
 }
-function dumpDexToFile(isDex,begin,processName) {
+function dumpDexToFile(isDex, begin, processName) {
     //console.log(hexdump(begin, { offset: 0, header: false, length: 64, ansi: false }));
     var dexType;
     isDex ? dexType = "dex" : dexType = "odex";
     var magic = Memory.readUtf8String(begin).replace(/\n/g, '');
-    var address = ptr(begin).add(isDex?0x20:0x1C);
+    var address = ptr(begin).add(isDex ? 0x20 : 0x1C);
     var dex_size = Memory.readInt(ptr(address));
     var dex_path = "/data/data/" + processName + "/" + dex_size + "." + dexType;
     var dex_file = new File(dex_path, "wb");
@@ -166,12 +166,12 @@ function dumpDexToFile(isDex,begin,processName) {
 function dumpDex(moduleFuncName, processName){
     if(moduleFuncName !== ""){
         var hookFunction;
-        if(getAndroidVersion() > 4){ // android 5 and later version
+        if(getAndroidVersion() > 4){
             hookFunction = Module.findExportByName("libart.so", moduleFuncName);
-        }else{ // android 4
-            hookFunction = Module.findExportByName("libdvm.so", moduleFuncName);  // check libdvm.so first
+        }else{
+            hookFunction = Module.findExportByName("libdvm.so", moduleFuncName);
             if(hookFunction == null) {
-                hookFunction = Module.findExportByName("libart.so", moduleFuncName); //// if not load libdvm.so, check libart.so
+                hookFunction = Module.findExportByName("libart.so", moduleFuncName);
             }
         }
         Interceptor.attach(hookFunction,{
@@ -215,9 +215,10 @@ function dumpDex(moduleFuncName, processName){
     }
 }
 
-//start dump dex file
+// Main code
 var moduleFucntionName = getFunctionName();
 var processName = getProcessName();
+
 if(moduleFucntionName !== "" && processName !== ""){
     dumpDex(moduleFucntionName, processName);
 }


### PR DESCRIPTION
FYI - Android 10 dex dumping is not working so far.

```sh
[20:36 edu@xps ~] >  frida -U -f xxx -l /tmp/dexDump.js --no-pause
     ____
    / _  |   Frida 12.8.20 - A world-class dynamic instrumentation toolkit
   | (_| |
    > _  |   Commands:
   /_/ |_|       help      -> Displays the help system
   . . . .       object?   -> Display information about 'object'
   . . . .       exit/quit -> Exit
   . . . .
   . . . .   More info at https://www.frida.re/docs/home/
Spawning `xxxxxxxxxxxx`...                                      
[14:37:37:862] Android Version: 1
```